### PR TITLE
Need to specify the exact type for JSON decode to work properly

### DIFF
--- a/pureport/client/model_aws_direct_connect_connection.go
+++ b/pureport/client/model_aws_direct_connect_connection.go
@@ -31,8 +31,8 @@ type AwsDirectConnectConnection struct {
 	Name             string                `json:"name"`
 	Nat              *NatConfig            `json:"nat,omitempty"`
 	Network          *Link                 `json:"network,omitempty"`
-	PrimaryGateway   *Gateway              `json:"primaryGateway,omitempty"`
-	SecondaryGateway *Gateway              `json:"secondaryGateway,omitempty"`
+	PrimaryGateway   *StandardGateway      `json:"primaryGateway,omitempty"`
+	SecondaryGateway *StandardGateway      `json:"secondaryGateway,omitempty"`
 	Speed            int32                 `json:"speed"`
 	State            string                `json:"state,omitempty"`
 	Type_            string                `json:"type"`

--- a/pureport/client/model_azure_express_route_connection.go
+++ b/pureport/client/model_azure_express_route_connection.go
@@ -31,8 +31,8 @@ type AzureExpressRouteConnection struct {
 	Name             string                `json:"name"`
 	Nat              *NatConfig            `json:"nat,omitempty"`
 	Network          *Link                 `json:"network,omitempty"`
-	PrimaryGateway   *Gateway              `json:"primaryGateway,omitempty"`
-	SecondaryGateway *Gateway              `json:"secondaryGateway,omitempty"`
+	PrimaryGateway   *StandardGateway      `json:"primaryGateway,omitempty"`
+	SecondaryGateway *StandardGateway      `json:"secondaryGateway,omitempty"`
 	Speed            int32                 `json:"speed"`
 	State            string                `json:"state,omitempty"`
 	Type_            string                `json:"type"`

--- a/pureport/client/model_dummy_connection.go
+++ b/pureport/client/model_dummy_connection.go
@@ -31,8 +31,8 @@ type DummyConnection struct {
 	Name             string                `json:"name"`
 	Nat              *NatConfig            `json:"nat,omitempty"`
 	Network          *Link                 `json:"network,omitempty"`
-	PrimaryGateway   *Gateway              `json:"primaryGateway,omitempty"`
-	SecondaryGateway *Gateway              `json:"secondaryGateway,omitempty"`
+	PrimaryGateway   *StandardGateway      `json:"primaryGateway,omitempty"`
+	SecondaryGateway *StandardGateway      `json:"secondaryGateway,omitempty"`
 	Speed            int32                 `json:"speed"`
 	State            string                `json:"state,omitempty"`
 	Type_            string                `json:"type"`

--- a/pureport/client/model_google_cloud_interconnect_connection.go
+++ b/pureport/client/model_google_cloud_interconnect_connection.go
@@ -31,8 +31,8 @@ type GoogleCloudInterconnectConnection struct {
 	Name                string            `json:"name"`
 	Nat                 *NatConfig        `json:"nat,omitempty"`
 	Network             *Link             `json:"network,omitempty"`
-	PrimaryGateway      *Gateway          `json:"primaryGateway,omitempty"`
-	SecondaryGateway    *Gateway          `json:"secondaryGateway,omitempty"`
+	PrimaryGateway      *StandardGateway  `json:"primaryGateway,omitempty"`
+	SecondaryGateway    *StandardGateway  `json:"secondaryGateway,omitempty"`
 	Speed               int32             `json:"speed"`
 	State               string            `json:"state,omitempty"`
 	Type_               string            `json:"type"`

--- a/pureport/client/model_site_ip_sec_vpn_connection.go
+++ b/pureport/client/model_site_ip_sec_vpn_connection.go
@@ -31,8 +31,8 @@ type SiteIpSecVpnConnection struct {
 	Name                      string                   `json:"name"`
 	Nat                       *NatConfig               `json:"nat,omitempty"`
 	Network                   *Link                    `json:"network,omitempty"`
-	PrimaryGateway            *Gateway                 `json:"primaryGateway,omitempty"`
-	SecondaryGateway          *Gateway                 `json:"secondaryGateway,omitempty"`
+	PrimaryGateway            *VpnGateway              `json:"primaryGateway,omitempty"`
+	SecondaryGateway          *VpnGateway              `json:"secondaryGateway,omitempty"`
 	Speed                     int32                    `json:"speed"`
 	State                     string                   `json:"state,omitempty"`
 	Type_                     string                   `json:"type"`

--- a/pureport/client/model_vpn_gateway.go
+++ b/pureport/client/model_vpn_gateway.go
@@ -21,7 +21,7 @@ type VpnGateway struct {
 	RemoteId           string         `json:"remoteId,omitempty"`
 	State              string         `json:"state,omitempty"`
 	Type_              string         `json:"type,omitempty"`
-	Auth               *VpnAuthConfig `json:"auth,omitempty"`
+	Auth               *PskAuthConfig `json:"auth,omitempty"`
 	CustomerGatewayIP  string         `json:"customerGatewayIP,omitempty"`
 	CustomerVtiIP      string         `json:"customerVtiIP,omitempty"`
 	PureportGatewayIP  string         `json:"pureportGatewayIP,omitempty"`


### PR DESCRIPTION
The JSON Unmarshalling code needs the exact type to be able to decode all of the parameters
correctly. Otherwise, fields will be ignored.