### PR TITLE
Change log for failing to read configuration file

### DIFF
--- a/pureport/credentials/viper_provider.go
+++ b/pureport/credentials/viper_provider.go
@@ -65,7 +65,7 @@ func (p *ViperProvider) Retrieve() (Value, error) {
 	p.retrieved = false
 
 	if err := vip.ReadInConfig(); err != nil {
-		log.Warningf("Error reading in configuration file: %s", err)
+		log.Infof("Configuration file not available: %s", err)
 	}
 
 	// Check environment first


### PR DESCRIPTION
Since we have many sources available for reading the authentication information,
change the configuration file log to info.