### PR TITLE
Use Refresh API endpoint when login token expired

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -139,6 +139,7 @@ golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e h1:bRhVy7zSSasaqNksaRZiA5EEI
 golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a h1:oWX7TPOiFAMXLq8o0ikBYfCJVlRHBcsciT5bXOrH628=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20190313220215-9f648a60d977 h1:actzWV6iWn3GLqN8dZjzsB+CLt+gaV2+wsxroxiQI8I=
 golang.org/x/net v0.0.0-20190313220215-9f648a60d977/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a h1:tImsplftrFpALCYumobsd0K86vlAs/eXGFms2txfJfA=
 golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/pureport/credentials/credentials.go
+++ b/pureport/credentials/credentials.go
@@ -18,6 +18,9 @@ type Value struct {
 	// Pureport Session Token
 	SessionToken string
 
+	// Pureport Refresh Token
+	RefreshToken string
+
 	// Provider used to get credentials
 	ProviderName string
 }

--- a/pureport/credentials/credentials_test.go
+++ b/pureport/credentials/credentials_test.go
@@ -106,7 +106,7 @@ func (p *mockProvider) IsExpired() bool {
 
 func TestCredentialExpiry(t *testing.T) {
 	m := mockProvider{}
-	m.Expiry.SetExpiration(time.Now().Add(time.Second*5), 0)
+	m.Expiry.SetExpiration(time.Now().Add(5*time.Second), 0)
 
 	c := NewCredentials(&m)
 	_, _ = c.Get()


### PR DESCRIPTION
To improve the login performance, we now use the login refresh endpoint when we have already authenticated but the token has expired.